### PR TITLE
Replace ReferenceEquals with pattern matching in NotEqual

### DIFF
--- a/src/Wolfgang.Extensions.IEquatable/IEquatableExtensions.cs
+++ b/src/Wolfgang.Extensions.IEquatable/IEquatableExtensions.cs
@@ -265,13 +265,6 @@ public static class IEquatableExtensions
     public static bool NotEqual<T>(this T item, T other)
 #endif
     {
-        // Both are null — they are equal, so NotEqual is false
-        if (item is null)
-        {
-            return other is not null;
-        }
-
-        // Both are not null (or other is null), compare using IEquatable<T>
-        return !item.Equals(other);
+        return !Equals(item, other);
     }
 }

--- a/src/Wolfgang.Extensions.IEquatable/IEquatableExtensions.cs
+++ b/src/Wolfgang.Extensions.IEquatable/IEquatableExtensions.cs
@@ -265,19 +265,13 @@ public static class IEquatableExtensions
     public static bool NotEqual<T>(this T item, T other)
 #endif
     {
-        // Point to the same item
-        if (ReferenceEquals(item, other))
+        // Both are null — they are equal, so NotEqual is false
+        if (item is null)
         {
-            return false;
+            return other is not null;
         }
 
-        // One is null but the other is not
-        if (ReferenceEquals(null, item))
-        {
-            return true;
-        }
-
-        // Both are not null, compare using IEquatable<T>
+        // Both are not null (or other is null), compare using IEquatable<T>
         return !item.Equals(other);
     }
 }


### PR DESCRIPTION
## Summary
- Replace `ReferenceEquals` null/identity checks with `is null` / `is not null` pattern matching in `NotEqual<T>`
- `ReferenceEquals` on unconstrained generic `T` boxes value types, causing unnecessary allocations for a check that always returns `false` on value types
- Simplifies the method from three checks to two

## Test plan
- [ ] Existing `NotEqual` tests pass
- [ ] No behavioral change — same results, less boxing

🤖 Generated with [Claude Code](https://claude.com/claude-code)