### PR TITLE
Replace noreply email with GitHub profile link in CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -64,10 +64,10 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement by contacting the
-repository owner through their GitHub profile at
-[github.com/Chris-Wolfgang](https://github.com/Chris-Wolfgang) and clearly
-labeling the message as a Code of Conduct report.
+reported to the community leaders responsible for enforcement by
+[privately reporting through the repository's Security tab](../../security/advisories/new).
+Although this tab is labeled for security vulnerabilities, it provides
+a private channel suitable for sensitive reports including Code of Conduct violations.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -64,8 +64,10 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-.
+reported to the community leaders responsible for enforcement by contacting the
+repository owner through their GitHub profile at
+[github.com/Chris-Wolfgang](https://github.com/Chris-Wolfgang) and clearly
+labeling the message as a Code of Conduct report.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
## Summary
Use GitHub profile for Code of Conduct enforcement reports instead of Security tab/noreply email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)