### PR TITLE
Remove paths-ignore from pr.yaml

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,9 +20,6 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary
- Removes `paths-ignore` from the `pull_request` trigger in `pr.yaml`
- Markdown-only PRs (e.g. CODE_OF_CONDUCT.md changes) were permanently blocked because required stage checks never triggered
- Matches the repo-template standard which has no `paths-ignore`

## Test plan
- [ ] Verify existing open PRs get CI checks after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)