### PR TITLE
Move analyzer package references from Directory.Build.props to projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,10 +6,10 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    
+
     <!-- Suppress warning about NetAnalyzers package since we're using SDK built-in -->
     <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
-    
+
     <!-- Treat warnings as errors in Release builds -->
     <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
   </PropertyGroup>
@@ -17,43 +17,5 @@
   <ItemGroup>
     <!-- Include BannedSymbols.txt as AdditionalFiles for BannedApiAnalyzers -->
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.txt" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Roslynator - Code quality and refactoring -->
-    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    
-    <!-- AsyncFixer - Async/await best practices -->
-    <PackageReference Include="AsyncFixer" Version="2.1.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    
-    <!-- Microsoft Threading Analyzers - Thread safety -->
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    
-    <!-- BannedApiAnalyzers - Prevent usage of specific APIs -->
-    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    
-    <!-- Meziantou - Comprehensive code quality -->
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.27">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-
-    <!-- SonarAnalyzer - Industry-standard analysis -->
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.24.0.138807">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/Wolfgang.Extensions.IEquatable/Wolfgang.Extensions.IEquatable.csproj
+++ b/src/Wolfgang.Extensions.IEquatable/Wolfgang.Extensions.IEquatable.csproj
@@ -36,4 +36,43 @@
 	  </None>
 	</ItemGroup>
 
+	<!-- Analyzer packages (moved from Directory.Build.props for per-project control) -->
+	<ItemGroup>
+		<!-- Roslynator - Code quality and refactoring -->
+		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- AsyncFixer - Async/await best practices -->
+		<PackageReference Include="AsyncFixer" Version="2.1.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- Microsoft Threading Analyzers - Thread safety -->
+		<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- BannedApiAnalyzers - Prevent usage of specific APIs -->
+		<PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- Meziantou - Comprehensive code quality -->
+		<PackageReference Include="Meziantou.Analyzer" Version="3.0.27">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- SonarAnalyzer - Industry-standard analysis -->
+		<PackageReference Include="SonarAnalyzer.CSharp" Version="10.24.0.138807">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
 </Project>

--- a/tests/Wolfgang.Extensions.IEquatable.Tests.Unit/Wolfgang.Extensions.IEquatable.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.IEquatable.Tests.Unit/Wolfgang.Extensions.IEquatable.Tests.Unit.csproj
@@ -100,4 +100,43 @@
 		<Using Include="Wolfgang.Extensions.IEquatable" />
 	</ItemGroup>
 
+	<!-- Analyzer packages (moved from Directory.Build.props for per-project control) -->
+	<ItemGroup>
+		<!-- Roslynator - Code quality and refactoring -->
+		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- AsyncFixer - Async/await best practices -->
+		<PackageReference Include="AsyncFixer" Version="2.1.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- Microsoft Threading Analyzers - Thread safety -->
+		<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- BannedApiAnalyzers - Prevent usage of specific APIs -->
+		<PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- Meziantou - Comprehensive code quality -->
+		<PackageReference Include="Meziantou.Analyzer" Version="3.0.27">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- SonarAnalyzer - Industry-standard analysis -->
+		<PackageReference Include="SonarAnalyzer.CSharp" Version="10.24.0.138807">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
Move analyzer `PackageReference` declarations out of `Directory.Build.props` and into each individual project (`src/` and `tests/`).

## Why
- Per-project control over which analyzers run and at what versions
- Easier to opt out of specific analyzers in specific projects (e.g., test-specific analyzers)
- Avoids surprise inheritance for new projects added later
- Analyzer/style configuration (`TreatWarningsAsErrors`, `EnforceCodeStyleInBuild`, `BannedSymbols.txt` `AdditionalFiles`) remains in `Directory.Build.props` since that's truly shared policy

## Packages moved
- Roslynator.Analyzers (4.15.0)
- AsyncFixer (2.1.0)
- Microsoft.VisualStudio.Threading.Analyzers (17.14.15)
- Microsoft.CodeAnalysis.BannedApiAnalyzers (4.14.0)
- Meziantou.Analyzer (3.0.27)
- SonarAnalyzer.CSharp (10.24.0.138807)

## Test plan
- [x] Solution builds clean (0 warnings, 0 errors) on Release
- [x] All 358 tests pass on net10.0
- [ ] Verify CI passes on all TFMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)