### PR TITLE
Fix Windows stage MSB1011 by specifying solution file

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -651,10 +651,22 @@ jobs:
             10.0.x
 
       - name: Restore dependencies
-        run: dotnet restore
+        shell: pwsh
+        run: |
+          $sln = Get-ChildItem -Path . -Filter *.slnx -File | Select-Object -First 1
+          if (-not $sln) { $sln = Get-ChildItem -Path . -Filter *.sln -File | Select-Object -First 1 }
+          if (-not $sln) { Write-Error "No solution file found"; exit 1 }
+          Write-Host "Restoring: $($sln.Name)"
+          dotnet restore $sln.FullName
 
       - name: Build solution
-        run: dotnet build --no-restore --configuration Release
+        shell: pwsh
+        run: |
+          $sln = Get-ChildItem -Path . -Filter *.slnx -File | Select-Object -First 1
+          if (-not $sln) { $sln = Get-ChildItem -Path . -Filter *.sln -File | Select-Object -First 1 }
+          if (-not $sln) { Write-Error "No solution file found"; exit 1 }
+          Write-Host "Building: $($sln.Name)"
+          dotnet build $sln.FullName --no-restore --configuration Release
 
       - name: Run all .NET tests (.NET 5.0-10.0 and Framework 4.6.2-4.8.1)
         shell: pwsh


### PR DESCRIPTION
## Summary
The Windows stage in `pr.yaml` uses bare `dotnet restore` / `dotnet build` which fails with `MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.`

The repo has two solution files (`IEquatable Extensions.slnx` and `Solution.slnx`), so MSBuild can't pick one automatically.

## Fix
Discover the `.slnx` (or `.sln`) and pass it explicitly to `dotnet restore` / `dotnet build`. Same pattern already used in `docfx.yaml`.

## Why this is blocking
PR #57 (Dependabot bump for `coverlet.collector`) is failing Stage 2 with this error. Other future Dependabot PRs will hit the same wall.

## Test plan
- [ ] Verify Stage 2 passes on this PR
- [ ] After merge, kick PR #57 to re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)