### PR TITLE
Upgrade release workflow actions to Node 24 and add .NET Core 3.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
+            3.1.x
             5.0.x
             6.0.x
             7.0.x
@@ -64,6 +65,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
+            3.1.x
             5.0.x
             6.0.x
             7.0.x


### PR DESCRIPTION
## Summary
- `actions/download-artifact`: v4 → v8.0.1
- `softprops/action-gh-release`: v2.5.0 (SHA `a06a81a0`) → v3.0.0 (SHA `b4309332`)
- Adds `3.1.x` to `dotnet-version` in all 3 `setup-dotnet` blocks.

Bundles two related release-workflow fixes:
1. Node 24 actions upgrade (mirrors [ETL-Test-Kit#54](https://github.com/Chris-Wolfgang/ETL-Test-Kit/pull/54)) — clears Node 20 deprecation warning.
2. .NET Core 3.1 SDK in setup-dotnet (mirrors [ETL-Json#54](https://github.com/Chris-Wolfgang/ETL-Json/pull/54)) — needed because test projects target `netcoreapp3.1`.

## Breaking change review
- `download-artifact` v5 changed the output path for single artifact downloads by ID. This workflow only downloads by `name:`, so unaffected.
- `action-gh-release` v3.0.0 is purely a Node 24 runtime bump per release notes.

## Test plan
- [ ] Next release runs without Node 20 deprecation warning
- [ ] .NET Core 3.1 SDK installs and netcoreapp3.1 tests succeed