### PR TITLE
Fix DocFX config placeholders blocking release docs deploy

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -5,12 +5,15 @@
       "src": [
         {
           "files": [
-			"src/<path>/<project>.csproj"
+            "src/Wolfgang.Extensions.IEquatable/Wolfgang.Extensions.IEquatable.csproj"
           ],
           "src": "../"
         }
       ],
-      "dest": "api"
+      "dest": "api",
+      "properties": {
+        "TargetFramework": "net8.0"
+      }
     }
   ],
   "build": {
@@ -37,8 +40,8 @@
       "default"
     ],
     "globalMetadata": {
-      "_appName": "",
-      "_appTitle": "<title>",
+      "_appName": "Wolfgang.Extensions.IEquatable",
+      "_appTitle": "Wolfgang.Extensions.IEquatable",
       "_enableSearch": true,
       "pdf": true
     }


### PR DESCRIPTION
## Summary
The v0.2.0 release workflow ([run 25292461327](https://github.com/Chris-Wolfgang/IEquatable-Extensions/actions/runs/25292461327)) failed at the "Verify build output" step in the docs job because `docfx_project/_site/api/` was never generated.

## Root cause
`docfx_project/docfx.json` still had unreplaced template placeholders from the repo-template setup:
- `src/<path>/<project>.csproj` (literal angle brackets — not a real project path)
- `_appName: ""` and `_appTitle: "<title>"`

DocFX silently couldn't find the project, so metadata generation produced nothing.

## Fix
- Point at the actual project: `src/Wolfgang.Extensions.IEquatable/Wolfgang.Extensions.IEquatable.csproj`
- Set `_appName` / `_appTitle` to `Wolfgang.Extensions.IEquatable`
- Add `TargetFramework: net8.0` to metadata properties (needed because the project multi-targets `net462;netstandard2.0;net8.0;net10.0` and DocFX's MSBuild can't process all of them at once)

## Test plan
- [x] `docfx metadata` succeeds locally
- [x] `docfx build` succeeds locally
- [x] `_site/api/` contains generated API HTML
- [ ] Verify the next release workflow run passes the docs job

🤖 Generated with [Claude Code](https://claude.com/claude-code)