### PR TITLE
chore: sync *.ps1 EOL fix from canonical

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,15 +25,13 @@ indent_size = 2
 [*.{yml,yaml}]
 indent_size = 2
 
-# PowerShell files
-# Only the indent override is needed; LF + UTF-8 (no BOM) come from the
-# global [*] section above. LF + no-BOM is required for the
-# `#!/usr/bin/env pwsh` shebang at the top of every script in scripts/
-# to work on Linux/macOS — CR breaks the kernel's exec lookup, and a
-# leading BOM prevents shebang recognition entirely.
-[*.ps1]
-indent_size = 4
-
+# PowerShell files inherit LF + UTF-8 (no BOM) + 4-space indent from
+# the global [*] section above — no [*.ps1] override needed. The
+# `charset = utf-8` setting is what prevents editors from writing a
+# BOM, which together with the LF requirement keeps the
+# `#!/usr/bin/env pwsh` shebang (where present) on scripts under
+# `scripts/` working on Linux/macOS — CR breaks the kernel's exec
+# lookup, and a leading BOM prevents shebang recognition entirely.
 # C# files
 [*.cs]
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -26,12 +26,13 @@ indent_size = 2
 indent_size = 2
 
 # PowerShell files
-# PowerShell uses CRLF to maintain compatibility with Windows and PowerShell conventions
-# This overrides the global end_of_line = lf setting and aligns with .gitattributes line 14
+# Only the indent override is needed; LF + UTF-8 (no BOM) come from the
+# global [*] section above. LF + no-BOM is required for the
+# `#!/usr/bin/env pwsh` shebang at the top of every script in scripts/
+# to work on Linux/macOS — CR breaks the kernel's exec lookup, and a
+# leading BOM prevents shebang recognition entirely.
 [*.ps1]
 indent_size = 4
-end_of_line = crlf
-charset = utf-8-bom
 
 # C# files
 [*.cs]

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,14 +9,15 @@
 *.fsx text eol=lf
 
 # Scripts
-# PowerShell scripts: CRLF line endings (intentional override)
-# PowerShell scripts: LF line endings, no BOM. Required for the
-# `#!/usr/bin/env pwsh` shebang to work on Linux/macOS — the kernel
-# parses CR as part of the interpreter name (looking for `pwsh\r`),
-# and a UTF-8 BOM before `#!` prevents shebang recognition entirely.
-# Modern PowerShell 7+ handles LF on Windows transparently; Git's
-# autocrlf still gives Windows users CRLF in their working tree if
-# desired without forcing CRLF into the index.
+# PowerShell scripts: LF line endings in the index. Required for the
+# `#!/usr/bin/env pwsh` shebang (where present) to work on Linux/macOS
+# — the kernel parses CR as part of the interpreter name (looking for
+# `pwsh\r`). BOM avoidance is enforced separately via `.editorconfig`
+# (`charset = utf-8` in the global `[*]` section); git attributes can
+# only normalize line endings, not byte-order marks. The top-of-file
+# `* text=auto eol=lf` rule also means Windows users get LF in their
+# working tree regardless of `core.autocrlf` — intentional so the
+# shebang works there too.
 *.ps1 text eol=lf
 
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -10,8 +10,14 @@
 
 # Scripts
 # PowerShell scripts: CRLF line endings (intentional override)
-# PowerShell convention uses Windows-style line endings.
-*.ps1 text eol=crlf
+# PowerShell scripts: LF line endings, no BOM. Required for the
+# `#!/usr/bin/env pwsh` shebang to work on Linux/macOS — the kernel
+# parses CR as part of the interpreter name (looking for `pwsh\r`),
+# and a UTF-8 BOM before `#!` prevents shebang recognition entirely.
+# Modern PowerShell 7+ handles LF on Windows transparently; Git's
+# autocrlf still gives Windows users CRLF in their working tree if
+# desired without forcing CRLF into the index.
+*.ps1 text eol=lf
 
 
 # Build and configuration files


### PR DESCRIPTION
## Summary
Syncs the canonical `*.ps1` EOL fix from [repo-template#347](https://github.com/Chris-Wolfgang/repo-template/pull/347) + [#348](https://github.com/Chris-Wolfgang/repo-template/pull/348). Removes the CRLF + UTF-8-BOM overrides for `*.ps1` files in `.gitattributes` and `.editorconfig`.

## Why
The `#!/usr/bin/env pwsh` shebang at the top of every script in `scripts/` doesn't work as an executable on Linux/macOS when files are stored with CRLF + BOM:

1. **CRLF:** kernel parses `#!/usr/bin/env pwsh\r` and tries to find an interpreter named `pwsh\r` — fails.
2. **BOM:** bytes `EF BB BF` appear *before* `#!`, so the kernel doesn't recognize the file as a shebang script at all.

## Changes
| File | Before | After |
|---|---|---|
| `.gitattributes` | `*.ps1 text eol=crlf` (with CRLF-rationale comment) | `*.ps1 text eol=lf` (with shebang-rationale comment) |
| `.editorconfig [*.ps1]` | `end_of_line = crlf`, `charset = utf-8-bom` | (both removed; LF + utf-8 from `[*]` defaults) |

## What does NOT change
Files in the index were already LF. No file content rewrites.

## Note about the protected-files guard
This PR touches `.editorconfig` (protected). `Detect .NET Projects` will fail it. Maintainer override required.

## Test plan
- [ ] Maintainer override + merge
- [ ] After merge, `git ls-files --eol scripts/*.ps1` shows `i/lf w/* attr/text eol=lf`
