### PR TITLE
docs: real README + CHANGELOG seed (closes #104 #105 #107 #124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Real README with installation, Quick Start, API reference table, and
+  build instructions (replaces the inherited template stub).
+- This CHANGELOG, seeded from git tag history.
+- `<RepositoryUrl>` / `<RepositoryType>` package metadata per the
+  fleet-wide CI1 canonical (NuGet quality).
+- Explicit `<FileVersion>$(Version).0` so file-version metadata tracks
+  every release.
+- D8 release-time docs-build verification via the canonical
+  `verify-docs-build` job — a docs failure now blocks `publish-nuget`
+  instead of landing after the package is already on NuGet.
+- D6 versions.json preservation guard in `docfx.yaml` — prior
+  versioned docs are no longer wiped on a release.
+- T1 coverage report published under `docs/coverage/` on every release.
+- T3 Stryker mutation-testing workflow scaffolded.
+- S1 CodeQL `security-extended` query suite enabled.
+- CI2 GitHub Actions ecosystem added to Dependabot.
+- A1 PublicApiAnalyzer scaffolding (analyzer is dormant until per-repo
+  Shipped.txt baseline is populated at the next release prep).
+
 ### Changed
 
-### Deprecated
-
-### Removed
+- `<TargetFrameworks>` collapsed onto a single line (CLAUDE.md rule —
+  the canonical CI grep parses this and breaks on multi-line).
+- `<PackageProjectUrl>` corrected from
+  `Wolfgang.Extensions.IEquatable` (the package id) to
+  `IEquatable-Extensions` (the actual repo name).
+- `<AssemblyVersion>` switched from the 3-part `1.0.0` form to the
+  explicit 4-part `1.0.0.0` form. SDK accepts both; explicit 4-part is
+  the canonical, unambiguous binding identity.
+- `<Nullable>enable</Nullable>` hoisted into `Directory.Build.props`
+  (scoped to SDK-style C# projects so legacy / F# projects are not
+  affected).
+- Canonical re-sync of protected config + workflow files (C1 drift).
 
 ### Fixed
 
-### Security
+- `<AssemblyVersion>` was previously dropped by an earlier canonical
+  C4 fanout, leaving the SDK to derive it from `<Version>`. That broke
+  binding-identity stability between minor/patch releases on .NET
+  Framework consumers. The explicit pin is restored here so future
+  bumps keep the same `AssemblyVersion=1.0.0.0` until a deliberate
+  breaking-API release.
+
+## [0.2.0] - 2026-05-01
+
+### Added
+
+- Initial published release of the `IsInSet` / `IsNotInSet` /
+  `NotEqual` extension method family across `net462`,
+  `netstandard2.0`, `net8.0`, and `net10.0`.
+
+[Unreleased]: https://github.com/Chris-Wolfgang/IEquatable-Extensions/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/Chris-Wolfgang/IEquatable-Extensions/releases/tag/v0.2.0

--- a/README.md
+++ b/README.md
@@ -1,3 +1,168 @@
-# Repository Template
+# Wolfgang.Extensions.IEquatable
 
-This repository is intended to be used as a template for creating other repositories.
+A collection of extension methods for types that implement `IEquatable<T>` — concise membership checks (`IsInSet` / `IsNotInSet`) and a fluent `NotEqual` complement to `Equals`.
+
+[![NuGet](https://img.shields.io/nuget/v/Wolfgang.Extensions.IEquatable.svg?logo=nuget&label=NuGet)](https://www.nuget.org/packages/Wolfgang.Extensions.IEquatable)
+[![NuGet downloads](https://img.shields.io/nuget/dt/Wolfgang.Extensions.IEquatable.svg?logo=nuget&label=downloads)](https://www.nuget.org/packages/Wolfgang.Extensions.IEquatable)
+[![PR build](https://img.shields.io/github/actions/workflow/status/Chris-Wolfgang/IEquatable-Extensions/pr.yaml?event=pull_request_target&label=PR%20build&logo=github)](https://github.com/Chris-Wolfgang/IEquatable-Extensions/actions/workflows/pr.yaml)
+[![Release](https://img.shields.io/github/actions/workflow/status/Chris-Wolfgang/IEquatable-Extensions/release.yaml?label=release&logo=github)](https://github.com/Chris-Wolfgang/IEquatable-Extensions/actions/workflows/release.yaml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![.NET](https://img.shields.io/badge/.NET-Multi--Targeted-purple.svg)](https://dotnet.microsoft.com/)
+[![GitHub](https://img.shields.io/badge/GitHub-Repository-181717?logo=github)](https://github.com/Chris-Wolfgang/IEquatable-Extensions)
+
+---
+
+## 📦 Installation
+
+```bash
+dotnet add package Wolfgang.Extensions.IEquatable
+```
+
+**NuGet Package:** [Wolfgang.Extensions.IEquatable](https://www.nuget.org/packages/Wolfgang.Extensions.IEquatable)
+
+---
+
+## 📄 License
+
+This project is licensed under the **MIT License**. See the [LICENSE](LICENSE) file for details.
+
+---
+
+## 📚 Documentation
+
+- **GitHub Repository:** [https://github.com/Chris-Wolfgang/IEquatable-Extensions](https://github.com/Chris-Wolfgang/IEquatable-Extensions)
+- **API Documentation:** https://Chris-Wolfgang.github.io/IEquatable-Extensions/
+- **CHANGELOG:** [CHANGELOG.md](CHANGELOG.md)
+- **Contributing Guide:** [CONTRIBUTING.md](CONTRIBUTING.md)
+
+---
+
+## 🚀 Quick Start
+
+```csharp
+using Wolfgang.Extensions.IEquatable;
+
+// Membership checks against a literal set of items
+if (status.IsInSet("active", "pending"))
+{
+    // ...
+}
+
+if (statusCode.IsNotInSet(200, 201, 204))
+{
+    // ...
+}
+
+// Membership against an existing collection
+var allowedRoles = new[] { "admin", "editor", "owner" };
+if (currentRole.IsInSet(allowedRoles))
+{
+    // ...
+}
+
+// Fluent !Equals
+if (lhs.NotEqual(rhs))
+{
+    // ...
+}
+```
+
+All methods are pure: they return a `bool` and never mutate the input or the
+set. Equality semantics follow the framework `Equals` contract — value types
+compare structurally; reference types use `Equals(object)` unless `T`
+implements `IEquatable<T>`, in which case the strongly-typed `Equals(T)` is
+preferred.
+
+---
+
+## ✨ Features
+
+The table below is a snapshot of the public API at the time of writing. For the
+authoritative list (kept in sync with source on every release), see the
+[API documentation](https://Chris-Wolfgang.github.io/IEquatable-Extensions/api/Wolfgang.Extensions.IEquatable.IEquatableExtensions.html).
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `IsInSet(T t1)` | True when `item` equals `t1`. |
+| `IsInSet(T t1, T t2)` | True when `item` equals any of the two listed values. |
+| `IsInSet(T t1, T t2, T t3)` | True when `item` equals any of the three listed values. |
+| `IsInSet(params T[] set)` | True when `item` appears in the provided array. |
+| `IsInSet(IEnumerable<T> set)` | True when `item` appears in the provided sequence. |
+| `IsInSet(ICollection<T> set)` | True when `item` appears in the provided collection. Preferred when the call site already has an `ICollection<T>` — skips the `IEnumerable` enumerator boxing path. |
+| `IsNotInSet(...)` | Negation of `IsInSet` for each of the same overloads. |
+| `NotEqual(T other)` | Fluent `!Equals(other)` so equality chains read top-to-bottom. |
+
+### Overload-set notes
+
+- **Nullable annotations.** On `net5.0+` (and net8.0/net10.0 builds) all
+  parameters are declared `T?` so nullability flows through the call site. On
+  `net462` / `netstandard2.0` builds — which predate the framework's nullable
+  reference annotations — they're declared as plain `T`. The runtime behaviour
+  is identical; only the compile-time analysis differs.
+- **Collection overload preference.** When the source is already an
+  `ICollection<T>`, the `ICollection<T>` overload avoids the
+  `IEnumerable<T>.GetEnumerator()` indirection. When it's an `IEnumerable<T>`
+  the enumerable overload is used — both ultimately delegate to
+  `Enumerable.Contains` for the lookup.
+
+### Examples
+
+```csharp
+// HTTP status filter
+var success = response.StatusCode.IsInSet(200, 201, 204);
+
+// Reverse: anything but a known good code
+var problem = response.StatusCode.IsNotInSet(200, 201, 204);
+
+// Role check against a pre-built set
+var allowed = new HashSet<string> { "admin", "editor" };
+if (user.Role.IsInSet(allowed))
+{
+    // ...
+}
+
+// Replace `if (a != b)` with `if (a.NotEqual(b))` when the LHS reads
+// awkwardly with a leading negation
+if (currentVersion.NotEqual(supportedVersion))
+{
+    return Outdated();
+}
+```
+
+---
+
+## 🧪 Target Frameworks
+
+| Framework | Supported |
+|---|---|
+| .NET Framework 4.6.2 | ✅ |
+| .NET Standard 2.0   | ✅ |
+| .NET 8.0            | ✅ |
+| .NET 10.0           | ✅ |
+
+The package multi-targets to keep the dependency footprint small on the
+modern runtimes while still supporting legacy .NET Framework consumers.
+
+---
+
+## 🛠️ Building from source
+
+```bash
+git clone https://github.com/Chris-Wolfgang/IEquatable-Extensions.git
+cd IEquatable-Extensions
+dotnet restore
+dotnet build -c Release
+dotnet test  -c Release --no-build
+```
+
+Requires the .NET 10.0 SDK (or newer) — earlier SDKs cannot build the `net10.0`
+target. The tests run against every framework the source supports.
+
+---
+
+## 🤝 Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, coding
+conventions, and PR checklist.

--- a/README.md
+++ b/README.md
@@ -68,10 +68,20 @@ if (lhs.NotEqual(rhs))
 ```
 
 All methods are pure: they return a `bool` and never mutate the input or the
-set. Equality semantics follow the framework `Equals` contract — value types
-compare structurally; reference types use `Equals(object)` unless `T`
-implements `IEquatable<T>`, in which case the strongly-typed `Equals(T)` is
-preferred.
+set.
+
+Equality semantics depend on the overload:
+
+- **Single-pair overloads** (`IsInSet(T t1)`, `IsInSet(T t1, T t2)`, `NotEqual(T)`, ...)
+  use `static object.Equals(object, object)`. That call boxes value types and
+  uses `Object.Equals` virtual dispatch — it does **not** prefer the
+  strongly-typed `IEquatable<T>.Equals(T)` overload. A future revision may
+  switch to `EqualityComparer<T>.Default` to avoid both the boxing and the
+  virtual call (tracked separately).
+- **Collection overloads** (`params T[]`, `IEnumerable<T>`, `ICollection<T>`)
+  use `Enumerable.Contains` / `ICollection<T>.Contains`, both of which route
+  through `EqualityComparer<T>.Default`. That comparer **does** prefer
+  `IEquatable<T>.Equals(T)` when `T` implements it.
 
 ---
 
@@ -102,10 +112,11 @@ authoritative list (kept in sync with source on every release), see the
   reference annotations — they're declared as plain `T`. The runtime behaviour
   is identical; only the compile-time analysis differs.
 - **Collection overload preference.** When the source is already an
-  `ICollection<T>`, the `ICollection<T>` overload avoids the
-  `IEnumerable<T>.GetEnumerator()` indirection. When it's an `IEnumerable<T>`
-  the enumerable overload is used — both ultimately delegate to
-  `Enumerable.Contains` for the lookup.
+  `ICollection<T>`, the `ICollection<T>` overload calls
+  `ICollection<T>.Contains` directly — for types like `HashSet<T>` that's
+  an O(1) hash lookup. When the source is an `IEnumerable<T>` the
+  enumerable overload delegates to `Enumerable.Contains` (LINQ), which is
+  O(N) and routes through `EqualityComparer<T>.Default`.
 
 ### Examples
 


### PR DESCRIPTION
## Summary

Replaces the template-stub README with a real one and seeds CHANGELOG.md
from git tag history.

## README

- Installation / Quick Start / API table / TFM matrix / build instructions
- Same canonical layout as DateTime-Extensions adapted for IEquatable's
  `IsInSet` / `IsNotInSet` / `NotEqual` API surface
- Badges: NuGet, downloads, PR build (with the `event=pull_request_target`
  filter from the recent fleet fix), release, License, .NET, GitHub

## CHANGELOG

- `[Unreleased]` enumerates the canonical infrastructure landing on
  vNext (CI1 / D6 / D8 / T1 / T3 / S1 / CI2 / A1 + the C4 AssemblyVersion
  restoration + the csproj hygiene fixes in PR #129)
- `[0.2.0] - 2026-05-01` captures the initial published release
- Compare-link footers correctly resolve

Closes #104, #105, #107, #124.