### PR TITLE
C5: strip trailing whitespace from IEquatableExtensions.cs (closes #97)

### DIFF
--- a/src/Wolfgang.Extensions.IEquatable/IEquatableExtensions.cs
+++ b/src/Wolfgang.Extensions.IEquatable/IEquatableExtensions.cs
@@ -37,9 +37,9 @@ public static class IEquatableExtensions
     /// <typeparam name="T">The type of the items in the set.</typeparam>
     /// <returns>True if the item is in the set; otherwise, false.</returns>
 #if NET5_0_OR_GREATER
-    public static bool IsInSet<T>(this T? item, T? t1, T? t2) 
+    public static bool IsInSet<T>(this T? item, T? t1, T? t2)
 #else
-    public static bool IsInSet<T>(this T item, T t1, T t2) 
+    public static bool IsInSet<T>(this T item, T t1, T t2)
 #endif
     {
         return Equals(item, t1) || Equals(item, t2);
@@ -58,7 +58,7 @@ public static class IEquatableExtensions
 #if NET5_0_OR_GREATER
     public static bool IsInSet<T>(this T? item, T? t1, T? t2, T? t3)
 #else
-    public static bool IsInSet<T>(this T item, T t1, T t2, T t3) 
+    public static bool IsInSet<T>(this T item, T t1, T t2, T t3)
 #endif
     {
         return Equals(item, t1) || Equals(item, t2) || Equals(item, t3);
@@ -77,7 +77,7 @@ public static class IEquatableExtensions
 #if NET5_0_OR_GREATER
     public static bool IsInSet<T>(this T? item, params T?[] set)
 #else
-    public static bool IsInSet<T>(this T item, params T[] set) 
+    public static bool IsInSet<T>(this T item, params T[] set)
 #endif
     {
         if (set == null)
@@ -101,7 +101,7 @@ public static class IEquatableExtensions
 #if NET5_0_OR_GREATER
     public static bool IsInSet<T>(this T? item, IEnumerable<T?> set)
 #else
-    public static bool IsInSet<T>(this T item, IEnumerable<T> set) 
+    public static bool IsInSet<T>(this T item, IEnumerable<T> set)
 #endif
     {
         if (set == null)
@@ -125,7 +125,7 @@ public static class IEquatableExtensions
 #if NET5_0_OR_GREATER
     public static bool IsInSet<T>(this T? item, ICollection<T?> set)
 #else
-    public static bool IsInSet<T>(this T item, ICollection<T> set) 
+    public static bool IsInSet<T>(this T item, ICollection<T> set)
 #endif
     {
         if (set == null)
@@ -167,7 +167,7 @@ public static class IEquatableExtensions
 #if NET5_0_OR_GREATER
     public static bool IsNotInSet<T>(this T? item, T? t1, T? t2)
 #else
-    public static bool IsNotInSet<T>(this T item, T t1, T t2) 
+    public static bool IsNotInSet<T>(this T item, T t1, T t2)
 #endif
     {
         return !IsInSet(item, t1, t2);
@@ -187,7 +187,7 @@ public static class IEquatableExtensions
 #if NET5_0_OR_GREATER
     public static bool IsNotInSet<T>(this T? item, T? t1, T? t2, T? t3)
 #else
-    public static bool IsNotInSet<T>(this T item, T t1, T t2, T t3) 
+    public static bool IsNotInSet<T>(this T item, T t1, T t2, T t3)
 #endif
     {
         return !IsInSet(item, t1, t2, t3);
@@ -206,7 +206,7 @@ public static class IEquatableExtensions
 #if NET5_0_OR_GREATER
     public static bool IsNotInSet<T>(this T? item, params T?[] set)
 #else
-    public static bool IsNotInSet<T>(this T item, params T[] set) 
+    public static bool IsNotInSet<T>(this T item, params T[] set)
 #endif
     {
         return !IsInSet(item, set);
@@ -225,7 +225,7 @@ public static class IEquatableExtensions
 #if NET5_0_OR_GREATER
     public static bool IsNotInSet<T>(this T? item, IEnumerable<T?> set)
 #else
-    public static bool IsNotInSet<T>(this T item, IEnumerable<T> set) 
+    public static bool IsNotInSet<T>(this T item, IEnumerable<T> set)
 #endif
     {
         return !IsInSet(item, set);
@@ -244,7 +244,7 @@ public static class IEquatableExtensions
 #if NET5_0_OR_GREATER
     public static bool IsNotInSet<T>(this T? item, ICollection<T?> set)
 #else
-    public static bool IsNotInSet<T>(this T item, ICollection<T> set) 
+    public static bool IsNotInSet<T>(this T item, ICollection<T> set)
 #endif
     {
         return !IsInSet(item, set);


### PR DESCRIPTION
## Summary

AI code-review pass on `src/Wolfgang.Extensions.IEquatable/IEquatableExtensions.cs`. Only one inline-actionable finding: 11 lines of trailing whitespace on the non-net5+ method declarations inside `#else` branches (missed by the May 2026 nullable hoist sweep).

## Other findings (deferred to separate PRs)

- The small-N `IsInSet` overloads (1/2/3 items) use static `Equals(object, object)`, which boxes value types. `EqualityComparer<T>.Default.Equals` would avoid the box but it's a behavior-sensitive perf change deserving its own PR + benchmark.
- README already documents the framework `Equals` contract semantics consistently with current behavior.

## Verified

```
dotnet build src/Wolfgang.Extensions.IEquatable -c Release  → 0 errors, 0 warnings
dotnet test -c Release --no-build                           → 358/358 across all TFMs
```

Closes #97.