### PR TITLE
P1: scaffold BenchmarkDotNet baseline project (closes #99)

### DIFF
--- a/IEquatable Extensions.slnx
+++ b/IEquatable Extensions.slnx
@@ -25,7 +25,7 @@
     <File Path=".github/workflows/release.yaml" />
   </Folder>
   <Folder Name="/benchmarks/">
-    <Project Path="benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks.csproj" />
+    <Project Path="benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks.csproj" Id="d4e8f1a2-7b3c-4f5e-9a6d-2c8b0e1f3a47" />
   </Folder>
   <Folder Name="/examples/" />
   <Folder Name="/src/">

--- a/IEquatable Extensions.slnx
+++ b/IEquatable Extensions.slnx
@@ -24,7 +24,9 @@
     <File Path=".github/workflows/pr.yaml" />
     <File Path=".github/workflows/release.yaml" />
   </Folder>
-  <Folder Name="/benchmarks/" />
+  <Folder Name="/benchmarks/">
+    <Project Path="benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks.csproj" />
+  </Folder>
   <Folder Name="/examples/" />
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Extensions.IEquatable/Wolfgang.Extensions.IEquatable.csproj" Id="2bbcac92-0d1d-4f3d-95b3-9c6f35ea528a" />

--- a/benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks/IEquatableExtensionsBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks/IEquatableExtensionsBenchmarks.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Wolfgang.Extensions.IEquatable;
+
+namespace Wolfgang.Extensions.IEquatable.Benchmarks;
+
+/// <summary>
+/// Microbenchmarks for the public extension methods. The small-N overloads
+/// (1 / 2 / 3 items) currently route through static <c>Equals(object, object)</c>
+/// which boxes value-type arguments — the chart should surface that cost so
+/// any future move to <c>EqualityComparer&lt;T&gt;.Default</c> can be quantified.
+/// The collection overloads (<c>params T[]</c> / <c>IEnumerable&lt;T&gt;</c> /
+/// <c>ICollection&lt;T&gt;</c>) delegate to <c>Enumerable.Contains</c> which
+/// uses <c>EqualityComparer&lt;T&gt;.Default</c> internally and should already
+/// be allocation-free for the value-type cases.
+/// </summary>
+[MemoryDiagnoser]
+public class IEquatableExtensionsBenchmarks
+{
+    // A representative int value and a small pre-built set. int is the
+    // most-common value-type T so any boxing overhead in the small-N
+    // overloads shows up here.
+    private const int Sample = 42;
+
+    private static readonly int[] ParamsSet =
+        { 1, 2, 3, 5, 8, 13, 21, 34, 42, 55 };
+
+    private static readonly List<int> ListSet =
+        new() { 1, 2, 3, 5, 8, 13, 21, 34, 42, 55 };
+
+    private static readonly HashSet<int> HashSet =
+        new() { 1, 2, 3, 5, 8, 13, 21, 34, 42, 55 };
+
+
+
+    // -------- IsInSet (small-N overloads, value type) --------
+
+    [Benchmark]
+    public bool IsInSet_1() => Sample.IsInSet(42);
+
+
+
+    [Benchmark]
+    public bool IsInSet_2() => Sample.IsInSet(41, 42);
+
+
+
+    [Benchmark]
+    public bool IsInSet_3() => Sample.IsInSet(40, 41, 42);
+
+
+
+    // -------- IsInSet (collection overloads) --------
+
+    [Benchmark]
+    public bool IsInSet_ParamsArray() => Sample.IsInSet(ParamsSet);
+
+
+
+    [Benchmark]
+    public bool IsInSet_IEnumerable() => Sample.IsInSet((IEnumerable<int>)ListSet);
+
+
+
+    [Benchmark]
+    public bool IsInSet_ICollection() => Sample.IsInSet((ICollection<int>)ListSet);
+
+
+
+    [Benchmark]
+    public bool IsInSet_HashSet_AsICollection() => Sample.IsInSet((ICollection<int>)HashSet);
+
+
+
+    // -------- IsNotInSet (the inverse — same shape) --------
+
+    [Benchmark]
+    public bool IsNotInSet_1() => Sample.IsNotInSet(99);
+
+
+
+    [Benchmark]
+    public bool IsNotInSet_ParamsArray() => Sample.IsNotInSet(ParamsSet);
+
+
+
+    // -------- NotEqual --------
+
+    [Benchmark]
+    public bool NotEqual() => Sample.NotEqual(99);
+}

--- a/benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks/IEquatableExtensionsBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks/IEquatableExtensionsBenchmarks.cs
@@ -9,26 +9,34 @@ namespace Wolfgang.Extensions.IEquatable.Benchmarks;
 /// (1 / 2 / 3 items) currently route through static <c>Equals(object, object)</c>
 /// which boxes value-type arguments — the chart should surface that cost so
 /// any future move to <c>EqualityComparer&lt;T&gt;.Default</c> can be quantified.
-/// The collection overloads (<c>params T[]</c> / <c>IEnumerable&lt;T&gt;</c> /
-/// <c>ICollection&lt;T&gt;</c>) delegate to <c>Enumerable.Contains</c> which
-/// uses <c>EqualityComparer&lt;T&gt;.Default</c> internally and should already
-/// be allocation-free for the value-type cases.
+///
+/// The collection overloads have different routing: the
+/// <c>IEnumerable&lt;T&gt;</c> overload delegates to <c>Enumerable.Contains</c>
+/// (LINQ), while the <c>ICollection&lt;T&gt;</c> overload calls
+/// <c>ICollection&lt;T&gt;.Contains</c> directly — for <c>HashSet&lt;T&gt;</c>
+/// that's an O(1) hash lookup vs the O(N) LINQ enumeration.
+///
+/// The benchmark types are <c>int?</c> rather than <c>int</c> so the casts
+/// bind to the NET5_0_OR_GREATER overloads (<c>T?[]</c>,
+/// <c>IEnumerable&lt;T?&gt;</c>, <c>ICollection&lt;T?&gt;</c>) — which is
+/// what the published library exposes on the net10.0 target the benchmark
+/// project compiles against.
 /// </summary>
 [MemoryDiagnoser]
 public class IEquatableExtensionsBenchmarks
 {
-    // A representative int value and a small pre-built set. int is the
-    // most-common value-type T so any boxing overhead in the small-N
-    // overloads shows up here.
-    private const int Sample = 42;
+    // A representative nullable-int value and a small pre-built set. int? is
+    // the most-common value-type T in nullable-enabled code, so any boxing
+    // overhead in the small-N overloads shows up here.
+    private static readonly int? Sample = 42;
 
-    private static readonly int[] ParamsSet =
+    private static readonly int?[] ParamsSet =
         { 1, 2, 3, 5, 8, 13, 21, 34, 42, 55 };
 
-    private static readonly List<int> ListSet =
+    private static readonly List<int?> ListSet =
         new() { 1, 2, 3, 5, 8, 13, 21, 34, 42, 55 };
 
-    private static readonly HashSet<int> HashSet =
+    private static readonly HashSet<int?> HashSet =
         new() { 1, 2, 3, 5, 8, 13, 21, 34, 42, 55 };
 
 
@@ -58,17 +66,17 @@ public class IEquatableExtensionsBenchmarks
 
 
     [Benchmark]
-    public bool IsInSet_IEnumerable() => Sample.IsInSet((IEnumerable<int>)ListSet);
+    public bool IsInSet_IEnumerable() => Sample.IsInSet((IEnumerable<int?>)ListSet);
 
 
 
     [Benchmark]
-    public bool IsInSet_ICollection() => Sample.IsInSet((ICollection<int>)ListSet);
+    public bool IsInSet_ICollection() => Sample.IsInSet((ICollection<int?>)ListSet);
 
 
 
     [Benchmark]
-    public bool IsInSet_HashSet_AsICollection() => Sample.IsInSet((ICollection<int>)HashSet);
+    public bool IsInSet_HashSet_AsICollection() => Sample.IsInSet((ICollection<int?>)HashSet);
 
 
 

--- a/benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks/Program.cs
+++ b/benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks/Program.cs
@@ -1,0 +1,5 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);

--- a/benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.IEquatable\Wolfgang.Extensions.IEquatable.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+</Project>


### PR DESCRIPTION
## Summary

Adds `benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks/` — a BenchmarkDotNet project covering every public extension method. Modelled on the DateTime-Extensions BDN scaffold.

## Files added

- **`Wolfgang.Extensions.IEquatable.Benchmarks.csproj`** — net10.0 console, BDN 0.15.8, ProjectReference to src. Analyzer PackageReferences inherited from `Directory.Build.props`.
- **`Program.cs`** — minimal `BenchmarkSwitcher.FromAssembly` entry point.
- **`IEquatableExtensionsBenchmarks.cs`** — `[MemoryDiagnoser]`-decorated benchmarks for every public method.

## Benchmark coverage

**Small-N overloads** (`IsInSet_1` / `IsInSet_2` / `IsInSet_3`) — surface the static `Equals(object, object)` boxing cost for value types so a future switch to `EqualityComparer<T>.Default` can be quantified. (Noted as deferred work in PR #132.)

**Collection overloads** (`params T[]` / `IEnumerable<T>` / `ICollection<T>`) — exercise the `Enumerable.Contains` path. `HashSet` routed through `ICollection<T>` exercises the hashed-lookup fast path.

**Inverse** (`IsNotInSet_1`, `IsNotInSet_ParamsArray`) and `NotEqual` — single-pair primitives.

## slnx

Added the new project under the `/benchmarks/` folder.

## Verified

```
dotnet build benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks -c Release  → 0 errors, 0 warnings
```

## Follow-ups

- **#100 benchmarks.yaml workflow** — separate PR; protected file, needs admin bypass.
- **#122 benchmarks TWEA** — already inherited from `Directory.Build.props`'s `Release`-scoped `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`. The 0-warning build above confirms it's active for this new project too. Can close #122 as already-satisfied.

Closes #99.