### PR TITLE
Address Copilot review on #136: CONTRIBUTING + README + BDN fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,60 +87,20 @@ All code is analyzed by these tools during build:
    - Security vulnerability detection
    - Code smell identification
 
-### Async-First Enforcement
+### Banned APIs
 
-This library **prohibits synchronous blocking calls** via `BannedSymbols.txt`. The following APIs are **banned**:
+`BannedSymbols.txt` is shared fleet-wide and bans the same set of obsolete
+or insecure APIs across every Wolfgang.* repo (e.g. `BinaryFormatter`,
+`new WebClient()`, `DateTime.Now` — prefer `DateTimeOffset.UtcNow`). The
+analyzer enforces these on every build.
 
-#### ❌ Blocking Async Operations
-```csharp
-// Banned - blocks threads
-task.Wait();
-task.Result;
-Task.WaitAll(tasks);
-
-// Required - truly async
-await task;
-await Task.WhenAll(tasks);
-```
-
-#### ❌ Synchronous I/O
-```csharp
-// Banned
-File.ReadAllText(path);
-stream.Read(buffer, 0, count);
-streamReader.ReadLine();
-
-// Required
-await File.ReadAllTextAsync(path);
-await stream.ReadAsync(buffer, 0, count);
-await streamReader.ReadLineAsync();
-```
-
-#### ❌ Thread Blocking
-```csharp
-// Banned
-Thread.Sleep(1000);
-Console.ReadLine();
-
-// Required
-await Task.Delay(1000);
-// Avoid blocking console reads in async code
-```
-
-#### ❌ Obsolete/Insecure APIs
-```csharp
-// Banned
-var client = new WebClient();
-var formatter = new BinaryFormatter();
-var now = DateTime.Now; // Use DateTimeOffset
-
-// Required
-var client = new HttpClient();
-// Use System.Text.Json.JsonSerializer
-var now = DateTimeOffset.UtcNow;
-```
-
-**Why?** This ensures all code is **truly asynchronous** and **non-blocking**, providing optimal performance in async contexts.
+The async-blocking bans (`task.Wait()`, `task.Result`, `File.ReadAllText`,
+`Thread.Sleep`, etc.) are also part of the shared list. They don't
+currently apply to this library — **`Wolfgang.Extensions.IEquatable` is a
+synchronous extension-method library** with no async APIs, no I/O, and no
+threading. The bans are inert here, but the shared rule set means that
+if async code is ever introduced to this project, it will be required to
+follow the fleet's async-first conventions from the start.
 
 ---
 
@@ -217,8 +177,10 @@ View the complete configuration in [.editorconfig](.editorconfig).
 - Add relevant tests for new features or bug fixes.
 - Document any public APIs with XML documentation comments.
 - Ensure all analyzer warnings are addressed (they're treated as errors in Release builds).
-- Use async/await patterns - no blocking calls allowed.
-- Include `CancellationToken` parameters in async methods where appropriate.
+- If async code is ever introduced, follow the fleet's async-first
+  conventions: avoid blocking calls (`task.Wait()`, `task.Result`,
+  `Thread.Sleep`), prefer async I/O, and accept `CancellationToken`
+  parameters where appropriate.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,23 @@ modern runtimes while still supporting legacy .NET Framework consumers.
 
 ---
 
+## 🔍 Code Quality & Static Analysis
+
+This project enforces **strict code quality standards** through **8 specialized analyzers**, an `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` Release gate, and custom rules:
+
+### Analyzers in Use
+
+1. **Microsoft.CodeAnalysis.NetAnalyzers** — Built-in .NET analyzers for correctness and performance
+2. **Roslynator.Analyzers** — Advanced refactoring and code quality rules
+3. **AsyncFixer** — Async/await best practices and anti-pattern detection
+4. **Microsoft.VisualStudio.Threading.Analyzers** — Thread safety and async patterns
+5. **Microsoft.CodeAnalysis.BannedApiAnalyzers** — Prevents usage of banned APIs (see `BannedSymbols.txt`); the async-blocking bans in the shared list are inert here since the library is fully synchronous
+6. **Meziantou.Analyzer** — Comprehensive code quality rules
+7. **SonarAnalyzer.CSharp** — Industry-standard code analysis
+8. **Microsoft.CodeAnalysis.PublicApiAnalyzers** — Tracks the public API surface via `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt`; surfaces additions/removals at compile time as a breaking-change review gate
+
+---
+
 ## 🛠️ Building from source
 
 ```bash

--- a/benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks/IEquatableExtensionsBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks/IEquatableExtensionsBenchmarks.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using BenchmarkDotNet.Attributes;
 using Wolfgang.Extensions.IEquatable;
 
@@ -10,11 +11,20 @@ namespace Wolfgang.Extensions.IEquatable.Benchmarks;
 /// which boxes value-type arguments — the chart should surface that cost so
 /// any future move to <c>EqualityComparer&lt;T&gt;.Default</c> can be quantified.
 ///
-/// The collection overloads have different routing: the
-/// <c>IEnumerable&lt;T&gt;</c> overload delegates to <c>Enumerable.Contains</c>
-/// (LINQ), while the <c>ICollection&lt;T&gt;</c> overload calls
-/// <c>ICollection&lt;T&gt;.Contains</c> directly — for <c>HashSet&lt;T&gt;</c>
-/// that's an O(1) hash lookup vs the O(N) LINQ enumeration.
+/// The collection overloads land on different code paths:
+/// <list type="bullet">
+/// <item><description>The <c>ICollection&lt;T&gt;</c> overload calls
+///   <c>ICollection&lt;T&gt;.Contains</c> directly — for <c>HashSet&lt;T&gt;</c>
+///   that's an O(1) hash lookup; for <c>List&lt;T&gt;</c> it's O(N).</description></item>
+/// <item><description>The <c>IEnumerable&lt;T&gt;</c> overload calls
+///   <c>Enumerable.Contains</c> (LINQ). That method internally checks whether
+///   the source is an <c>ICollection&lt;T&gt;</c> and dispatches to its
+///   <c>.Contains</c> when so — meaning passing a <c>List&lt;T&gt;</c> cast
+///   to <c>IEnumerable&lt;T&gt;</c> doesn't actually exercise the iterator
+///   fallback. To force that fallback in <c>IsInSet_IEnumerable_Iterator</c>
+///   the benchmark wraps the list in a <c>Select</c> projection, which
+///   produces a non-<c>ICollection&lt;T&gt;</c> enumerable.</description></item>
+/// </list>
 ///
 /// The benchmark types are <c>int?</c> rather than <c>int</c> so the casts
 /// bind to the NET5_0_OR_GREATER overloads (<c>T?[]</c>,
@@ -65,18 +75,27 @@ public class IEquatableExtensionsBenchmarks
 
 
 
+    // Note: passing (IEnumerable<int?>)ListSet here would NOT exercise the
+    // LINQ iterator fallback — Enumerable.Contains detects ICollection<T>
+    // and dispatches to its .Contains. To actually measure the iterator
+    // path, see IsInSet_IEnumerable_Iterator below.
     [Benchmark]
-    public bool IsInSet_IEnumerable() => Sample.IsInSet((IEnumerable<int?>)ListSet);
+    public bool IsInSet_IEnumerable_FromList() => Sample.IsInSet((IEnumerable<int?>)ListSet);
 
 
 
     [Benchmark]
-    public bool IsInSet_ICollection() => Sample.IsInSet((ICollection<int?>)ListSet);
+    public bool IsInSet_IEnumerable_Iterator() => Sample.IsInSet(ListSet.Select(x => x));
 
 
 
     [Benchmark]
-    public bool IsInSet_HashSet_AsICollection() => Sample.IsInSet((ICollection<int?>)HashSet);
+    public bool IsInSet_ICollection_List() => Sample.IsInSet((ICollection<int?>)ListSet);
+
+
+
+    [Benchmark]
+    public bool IsInSet_ICollection_HashSet() => Sample.IsInSet((ICollection<int?>)HashSet);
 
 
 


### PR DESCRIPTION
## Summary

Stacks on top of PR #136 (vNext → main) to address its 3 Copilot review threads. Once this merges into vNext, PR #136's vNext base auto-promotes so the fixes ride along.

## Changes

### `CONTRIBUTING.md`
The "Async-First Enforcement" section was a copy-paste from a different repo presenting `await File.ReadAllTextAsync(...)` as required guidance. This library is purely synchronous — no async APIs, no I/O, no threading. The async-blocking bans in `BannedSymbols.txt` are part of the shared fleet rule set but inert here. Reworded to make that explicit. Also reworded the related Guidelines bullet at the bottom.

### `README.md`
Added the missing `🔍 Code Quality & Static Analysis` section between `🧪 Target Frameworks` and `🛠️ Building from source`, matching the canonical layout DateTime-Extensions established (the same 8 analyzers, with a small tweak to call out that the async-blocking bans are inert here).

### `benchmarks/.../IEquatableExtensionsBenchmarks.cs`
Copilot caught a real design flaw: `IsInSet_IEnumerable` was passing `(IEnumerable<int?>)ListSet`, but `Enumerable.Contains` internally checks for `ICollection<T>` and dispatches to its `.Contains` — so the benchmark measured the same path as `IsInSet_ICollection`.

Split into two benchmarks:
- **`IsInSet_IEnumerable_FromList`** — keeps the cast, measures the `Enumerable.Contains` down-cast path.
- **`IsInSet_IEnumerable_Iterator`** — wraps `ListSet` in `Select(x => x)` to force a non-`ICollection<T>` enumerable, which actually exercises the LINQ iterator fallback the doc/README promised.

Renamed `IsInSet_ICollection` → `IsInSet_ICollection_List` and `IsInSet_HashSet_AsICollection` → `IsInSet_ICollection_HashSet` so the gh-pages chart labels make clear which backing collection is in play.

## Verified

```
dotnet build benchmarks/Wolfgang.Extensions.IEquatable.Benchmarks -c Release  → 0 errors, 0 warnings
```

Addresses 3 Copilot threads on PR #136. After this merges, PR #136 will have no open review comments.