### PR TITLE
docs: fix DocFX landing stub + bogus setup instructions (D7, closes #108)

### DIFF
--- a/docfx_project/docs/setup.md
+++ b/docfx_project/docs/setup.md
@@ -37,9 +37,9 @@ For most projects, a standard NuGet package installation is sufficient:
 dotnet add package Wolfgang.Extensions.IEquatable
 ```
 
-### Development Build Installation
+### Local Build Installation
 
-To use the latest development build from a local source:
+To build and consume the package from a local source:
 
 1. Clone the repository:
    ```bash
@@ -47,27 +47,23 @@ To use the latest development build from a local source:
    cd IEquatable-Extensions
    ```
 
-2. Checkout the develop branch:
-   ```bash
-   git checkout develop
-   ```
-
-3. Build the project:
+2. Build the project:
    ```bash
    dotnet build --configuration Release
    ```
 
-4. Pack the NuGet package:
+3. Pack the NuGet package (the `.nupkg` is written to the project's
+   `bin/Release/` directory):
    ```bash
    dotnet pack --configuration Release
    ```
 
-5. Add the local package source:
+4. Add the output directory as a local package source:
    ```bash
-   dotnet nuget add source ./artifacts/packages/Release --name LocalIEquatableExtensions
+   dotnet nuget add source ./src/Wolfgang.Extensions.IEquatable/bin/Release --name LocalIEquatableExtensions
    ```
 
-6. Install from the local source:
+5. Install from the local source:
    ```bash
    dotnet add package Wolfgang.Extensions.IEquatable --source LocalIEquatableExtensions
    ```

--- a/docfx_project/docs/setup.md
+++ b/docfx_project/docs/setup.md
@@ -58,13 +58,21 @@ To build and consume the package from a local source:
    dotnet pack --configuration Release
    ```
 
-4. Add the output directory as a local package source:
+4. Add the output directory as a local package source. `dotnet nuget add
+   source` records the path verbatim in your user-global NuGet config, so
+   it must be an **absolute** path — a relative path would stop resolving
+   once you run `dotnet` from a different directory:
    ```bash
-   dotnet nuget add source ./src/Wolfgang.Extensions.IEquatable/bin/Release --name LocalIEquatableExtensions
+   # from the cloned repo root; resolves to an absolute path
+   dotnet nuget add source "$(pwd)/src/Wolfgang.Extensions.IEquatable/bin/Release" --name LocalIEquatableExtensions
    ```
+   On Windows PowerShell, use `(Resolve-Path ./src/Wolfgang.Extensions.IEquatable/bin/Release)` instead of `$(pwd)/...`.
 
-5. Install from the local source:
+5. Install from the local source — run this **in your consuming project**,
+   not in the library repo (`dotnet add package` targets the project in
+   the current directory):
    ```bash
+   cd /path/to/your/project
    dotnet add package Wolfgang.Extensions.IEquatable --source LocalIEquatableExtensions
    ```
 

--- a/docfx_project/index.md
+++ b/docfx_project/index.md
@@ -2,8 +2,47 @@
 _layout: landing
 ---
 
-# Title
+# Wolfgang.Extensions.IEquatable
 
-## Quick Start Notes:
+A lightweight .NET library of extension methods that simplify common equality
+comparison patterns — concise membership checks (`IsInSet` / `IsNotInSet`) and a
+fluent `NotEqual` complement to `Equals`.
 
-<!--1. Add images to the *images* folder if the file is referencing an image.-->
+## Quick Start
+
+```csharp
+using Wolfgang.Extensions.IEquatable;
+
+// Membership check instead of a verbose OR chain
+if (status.IsInSet("active", "pending", "approved"))
+{
+    // ...
+}
+
+// Inverse — instead of a verbose AND chain
+if (role.IsNotInSet("admin", "moderator", "owner"))
+{
+    throw new UnauthorizedAccessException();
+}
+
+// Fluent inequality
+if (currentVersion.NotEqual(supportedVersion))
+{
+    // ...
+}
+```
+
+## Where to next
+
+- [Introduction](docs/introduction.md) — what the library is and when to use it
+- [Getting Started](docs/getting-started.md) — install and first usage
+- [Setup](docs/setup.md) — configuration and integration scenarios
+- [API Reference](api/Wolfgang.Extensions.IEquatable.IEquatableExtensions.html) — every method, generated from source
+
+## Install
+
+```bash
+dotnet add package Wolfgang.Extensions.IEquatable
+```
+
+Targets .NET Framework 4.6.2, .NET Standard 2.0, .NET 8.0, and .NET 10.0.


### PR DESCRIPTION
## Summary

D7 markdown-accuracy audit (#108) of the `docfx_project/` content files. Two real inaccuracies fixed; everything else verified accurate and left as-is.

## Fixed

### `docfx_project/index.md` — DocFX landing page
Was an **unmodified template stub** (`# Title` + a commented-out "add images" note). This is the page served at the docs site root behind the version picker. Replaced with a real landing page: one-line description, Quick Start with the three actual methods, doc/API links, install command, TFM list.

### `docfx_project/docs/setup.md` — "Development Build Installation"
Two **fabricated instructions** that would fail if followed:
- `git checkout develop` — there is no `develop` branch (trunk-based; work is on `feature/*` off `main`).
- `dotnet nuget add source ./artifacts/packages/Release` — `dotnet pack` writes to the project's `bin/Release/`, not `./artifacts/`.

Renamed to "Local Build Installation", dropped the develop-branch step, corrected the source path.

## Audited, accurate, left unchanged
`introduction.md`, `getting-started.md`, `readme.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `docs/README-FORMATTING.md`, `docs/RELEASE-WORKFLOW-SETUP.md`, `docs/WORKFLOW_SECURITY.md`, `.github/copilot-instructions.md`.

The illustrative `Version="1.0.0"` PackageReference snippets each carry a "replace with latest" note — fine as examples, not changed.

## Not a protected file
Pure markdown — normal merge, no admin-bypass.

Closes #108.
