### PR TITLE
docs(docfx): add custom favicon.svg derived from logo identity

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -32,6 +32,7 @@
     "resource": [
       {
         "files": [
+          "favicon.svg",
           "logo.svg",
           "images/**",
           "public/**",
@@ -49,6 +50,7 @@
       "_appName": "Wolfgang.Extensions.IEquatable",
       "_appTitle": "Wolfgang.Extensions.IEquatable Documentation",
       "_appLogoPath": "logo.svg",
+      "_appFaviconPath": "favicon.svg",
       "_enableSearch": true,
       "_appFooter": "Made with DocFX <script>(function(){var r='/';if(window.location.hostname.endsWith('.github.io')){var s=window.location.pathname.split('/').filter(Boolean);if(s.length)r='/'+s[0]+'/';}var t=document.createElement('script');t.src=r+'public/version-picker.js';t.async=true;document.head.appendChild(t);})();</script>",
       "_disableSidebar": false,


### PR DESCRIPTION
## Summary
Adds a custom SVG favicon (purple W on dark rounded background, matching `#7c23bb` from `logo.svg`) so the browser tab shows the project identity instead of the generic DocFX-shipped favicon. Mirrors what landed in [In-memory-Logger PR #151](https://github.com/Chris-Wolfgang/In-memory-Logger/pull/151).

## What changed (2 files, +3 lines)
- `docfx_project/favicon.svg` (new, 32x32 viewBox, self-contained — no remote font dependency at favicon sizes)
- `docfx_project/docfx.json`:
  - `resource.files`: add `favicon.svg`
  - `globalMetadata._appFaviconPath`: `favicon.svg`

## Browser support
SVG favicon is supported by all evergreen browsers (Chrome 80+, Firefox 41+, Safari 9+, Edge 80+). Legacy-browser `.ico` fallback can be generated later if needed.

## Test plan
- [ ] CI green
- [ ] After merge + docfx workflow: `<link rel="icon" href="favicon.svg">` in rendered `<head>`
- [ ] Browser tab shows custom W instead of generic DocFX icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)