### PR TITLE
docfx.json: wire favicon assets (was silently skipped in earlier fanout)

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -33,6 +33,9 @@
       {
         "files": [
           "logo.svg",
+          "apple-touch-icon.png",
+          "favicon.ico",
+          "favicon.svg",
           "images/**",
           "public/**",
           "versions.json"
@@ -49,6 +52,7 @@
       "_appName": "Wolfgang.Extensions.IEquatable",
       "_appTitle": "Wolfgang.Extensions.IEquatable Documentation",
       "_appLogoPath": "logo.svg",
+      "_appFaviconPath": "favicon.svg",
       "_enableSearch": true,
       "_appFooter": "Made with DocFX <script>(function(){var r='/';if(window.location.hostname.endsWith('.github.io')){var s=window.location.pathname.split('/').filter(Boolean);if(s.length)r='/'+s[0]+'/';}var t=document.createElement('script');t.src=r+'public/version-picker.js';t.async=true;document.head.appendChild(t);})();</script>",
       "_disableSidebar": false,


### PR DESCRIPTION
## Summary

The earlier favicon fanout (feature/docs-favicon) added `docfx_project/favicon.svg|.ico` + `apple-touch-icon.png` but its docfx.json patch silently failed on most repos. The files are on main, DocFX has no idea about them, and the rendered site still uses the default DocFX favicon instead of the W.

This PR adds the wiring:

- `build.resource[0].files` — adds `favicon.svg`, `favicon.ico`, `apple-touch-icon.png` so the assets are copied to `_site/`
- `build.globalMetadata._appFaviconPath` — set to `favicon.svg`, the DocFX modern template's native favicon hook (emits `<link rel="icon" href="favicon.svg">`)

No other changes to docfx.json. Built with the same Node.js JSON-aware transform used for the canonical ruleset fixes, so no comment/key-order corruption.