### PR TITLE
Add canonical docfx_project/toc.yml (Documentation + API Reference nav)

### DIFF
--- a/docfx_project/toc.yml
+++ b/docfx_project/toc.yml
@@ -1,0 +1,5 @@
+- name: Documentation
+  href: docs/toc.yml
+- name: API Reference
+  href: api/toc.yml
+  homepage: api/index.md


### PR DESCRIPTION
## Summary

Adds the missing top-level `docfx_project/toc.yml` so the deployed docs site surfaces the **Documentation** and **API Reference** nav entries in the header. Without this file the site renders without those menu links.

All other canonical assets (logo, favicon, version picker, versions.json, docfx.json resource.files) are already in place.

## After merge

Re-dispatch `docfx.yaml` so `versions/latest/` redeploys.